### PR TITLE
【メモ画面作成_痙攣】写真選択とカメラを実装しました

### DIFF
--- a/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.swift
+++ b/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.swift
@@ -57,9 +57,19 @@ final class ConvulsionsViewController: UIViewController {
     }
     /// 写真挿入ボタンをタップ
     @IBAction private func tapPhotoButton(_ sender: UIButton) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .photoLibrary
+        picker.delegate = self
+        present(picker, animated: true)
+        self.present(picker, animated: true)
     }
     /// カメラ・動画起動ボタンをタップ
     @IBAction private func tapCameraButton(_ sender: UIButton) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = self
+        // UIImagePickerController カメラを起動する
+        present(picker, animated: true, completion: nil)
     }
     /// 削除ボタンをタップ
     @IBAction private func tapTrashButton(_ sender: UIButton) {
@@ -159,5 +169,21 @@ final class ConvulsionsViewController: UIViewController {
     /// 画面のどこかをタップしてキーボードを閉じるメソッド
     @objc private func handleTap() {
         view.endEditing(true)
+    }
+}
+
+// MARK: - UIImagePickerControllerDelegate
+
+extension ConvulsionsViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let selectedImage = info[.originalImage] as? UIImage {
+            imageView.image = selectedImage
+        }
+        self.dismiss(animated: true)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        self.dismiss(animated: true)
     }
 }

--- a/MamaPapaMedicalRecord/Memo Tab/FeverViewController.swift
+++ b/MamaPapaMedicalRecord/Memo Tab/FeverViewController.swift
@@ -61,7 +61,6 @@ final class FeverViewController: UIViewController {
     }
     /// カメラ・動画挿入ボタンをタップ
     @IBAction private func tapCameraButton(_ sender: UIButton) {
-
         let picker = UIImagePickerController()
         picker.sourceType = .camera
         picker.delegate = self


### PR DESCRIPTION
【メモ画面作成_痙攣】写真選択とカメラを実装
## やったこと
* 【メモ画面作成_痙攣】写真選択とカメラを実装

## 画像　
<img width="240" alt="スクリーンショット 2023-10-05 13 59 56" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/d2034900-bfe8-4c94-beb1-91ffcab21c2d">
<img width="240" alt="スクリーンショット 2023-10-05 14 00 04" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/c4b589b6-2af3-47cd-9d52-b63b259c6a34">
<img width="240" alt="スクリーンショット 2023-10-05 14 00 15" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/ca9f447d-ee33-4dd6-a46a-abdb7ffaf162">


## 動作確認
- カメラアイコンをタップして、写真アルバムに遷移できることを確認した
- 写真をimageviewに挿入できることを確認した
- 写真アイコンをタップして、カメラに遷移できることを確認した

レビューをお願いします。@tomokazuTakahashi2