### PR TITLE
【メモ画面作成_下痢】写真選択とカメラを実装およびボタンの大きさを修正しました。

### DIFF
--- a/MamaPapaMedicalRecord/Memo Tab/DiarrheaViewController.swift
+++ b/MamaPapaMedicalRecord/Memo Tab/DiarrheaViewController.swift
@@ -75,9 +75,19 @@ final class DiarrheaViewController: UIViewController {
     }
     /// 写真挿入ボタンをタップ
     @IBAction private func tapPhotoButton(_ sender: UIButton) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .photoLibrary
+        picker.delegate = self
+        present(picker, animated: true)
+        self.present(picker, animated: true)
     }
     /// カメラ・動画起動ボタンをタップ
     @IBAction private func tapCameraButton(_ sender: UIButton) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = self
+        // UIImagePickerController カメラを起動する
+        present(picker, animated: true, completion: nil)
     }
     /// 削除ボタンをタップ
     @IBAction private func tapTrashButton(_ sender: UIButton) {
@@ -178,5 +188,21 @@ final class DiarrheaViewController: UIViewController {
     /// 画面のどこかをタップしてキーボードを閉じるメソッド
     @objc private func handleTap() {
         view.endEditing(true)
+    }
+}
+
+// MARK: - UIImagePickerControllerDelegate
+
+extension DiarrheaViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let selectedImage = info[.originalImage] as? UIImage {
+            imageView.image = selectedImage
+        }
+        self.dismiss(animated: true)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        self.dismiss(animated: true)
     }
 }

--- a/MamaPapaMedicalRecord/Memo Tab/DiarrheaViewController.xib
+++ b/MamaPapaMedicalRecord/Memo Tab/DiarrheaViewController.xib
@@ -291,7 +291,7 @@
                             <rect key="frame" x="0.0" y="200" width="414" height="50"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jdo-3e-Ghy" customClass="CustomButton" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
-                                    <rect key="frame" x="80" y="10" width="103" height="30"/>
+                                    <rect key="frame" x="77.5" y="10" width="115" height="30"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="fz8-zl-fWm"/>
@@ -301,8 +301,8 @@
                                         <attributedString key="attributedTitle">
                                             <fragment content="赤い箇所がある">
                                                 <attributes>
-                                                    <font key="NSFont" metaFont="smallSystem"/>
-                                                    <font key="NSOriginalFont" metaFont="system"/>
+                                                    <font key="NSFont" size="13" name=".HiraKakuInterface-W3"/>
+                                                    <font key="NSOriginalFont" metaFont="smallSystem"/>
                                                 </attributes>
                                             </fragment>
                                         </attributedString>
@@ -323,23 +323,15 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgX-LN-Qrr" customClass="CustomButton" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
-                                    <rect key="frame" x="188" y="10" width="81" height="30"/>
+                                    <rect key="frame" x="192.5" y="10" width="102.5" height="30"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="81" id="5w0-cm-2Kr"/>
+                                        <constraint firstAttribute="width" constant="102.5" id="5w0-cm-2Kr"/>
                                         <constraint firstAttribute="height" constant="30" id="cxz-fL-w2m"/>
                                     </constraints>
                                     <state key="normal" title="Button"/>
-                                    <buttonConfiguration key="configuration" style="plain">
-                                        <attributedString key="attributedTitle">
-                                            <fragment content="その他">
-                                                <attributes>
-                                                    <font key="NSFont" size="13" name="HiraginoSans-W3"/>
-                                                    <font key="NSOriginalFont" size="12" name="Helvetica"/>
-                                                    <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                </attributes>
-                                            </fragment>
-                                        </attributedString>
+                                    <buttonConfiguration key="configuration" style="plain" title="その他">
+                                        <fontDescription key="titleFontDescription" name="HiraginoSans-W3" family="Hiragino Sans" pointSize="17"/>
                                     </buttonConfiguration>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
@@ -357,9 +349,8 @@
                                     </connections>
                                 </button>
                                 <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Pa5-x2-1x4">
-                                    <rect key="frame" x="269" y="10" width="116" height="30"/>
+                                    <rect key="frame" x="295" y="10" width="89" height="30"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="116" id="pFY-zX-ALu"/>
                                         <constraint firstAttribute="height" constant="30" id="rAa-gF-9ID"/>
                                     </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -372,8 +363,9 @@
                                 <constraint firstAttribute="height" constant="50" id="6pD-a0-gsG"/>
                                 <constraint firstItem="Pa5-x2-1x4" firstAttribute="centerY" secondItem="TeC-iD-agM" secondAttribute="centerY" id="7JX-4o-Ax6"/>
                                 <constraint firstItem="Pa5-x2-1x4" firstAttribute="leading" secondItem="mgX-LN-Qrr" secondAttribute="trailing" id="7OO-r5-Bup"/>
-                                <constraint firstItem="mgX-LN-Qrr" firstAttribute="leading" secondItem="Jdo-3e-Ghy" secondAttribute="trailing" constant="5" id="k9S-NJ-oQd"/>
-                                <constraint firstItem="Jdo-3e-Ghy" firstAttribute="leading" secondItem="TeC-iD-agM" secondAttribute="leading" constant="80" id="r7s-MS-7jT"/>
+                                <constraint firstAttribute="trailing" secondItem="Pa5-x2-1x4" secondAttribute="trailing" constant="30" id="aJt-va-byI"/>
+                                <constraint firstItem="mgX-LN-Qrr" firstAttribute="leading" secondItem="Jdo-3e-Ghy" secondAttribute="trailing" id="k9S-NJ-oQd"/>
+                                <constraint firstItem="Jdo-3e-Ghy" firstAttribute="leading" secondItem="TeC-iD-agM" secondAttribute="leading" constant="77.5" id="r7s-MS-7jT"/>
                                 <constraint firstItem="Jdo-3e-Ghy" firstAttribute="centerY" secondItem="TeC-iD-agM" secondAttribute="centerY" id="xac-a2-wgI"/>
                             </constraints>
                         </view>


### PR DESCRIPTION
## やったこと
* 【メモ画面作成_下痢】写真選択とカメラを実装
* ボタンの大きさを修正

## 画像　
<img width="240" alt="スクリーンショット 2023-10-05 14 19 47" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/bac94a6e-2a0f-4901-b641-0912e0c7d129">
<img width="240" alt="スクリーンショット 2023-10-05 14 19 54" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/deb9b7a6-d349-49e0-a862-c22a5d850d1a">
<img width="240" alt="スクリーンショット 2023-10-05 14 20 01" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/8abc39d9-5326-47eb-b458-512c07f86f64">

## 動作確認
- 写真アイコンをタップして、アルバムに画面遷移ができることを確認した
- アルバムの写真をimageviewに挿入できたことを確認した
- カメラアイコンをタップして、カメラ画面遷移ができることを確認した
- ボタンの幅を修正（全て同じ幅にした）
@tomokazuTakahashi2 
