### PR TITLE
【記録ノート一覧画面作成】削除ボタンの実装および表紙画面の削除ボタンの実装

### DIFF
--- a/MamaPapaMedicalRecord/Cover Tab/CoverViewController.swift
+++ b/MamaPapaMedicalRecord/Cover Tab/CoverViewController.swift
@@ -137,7 +137,7 @@ extension CoverViewController: UITableViewDelegate {
         return 30
     }
     
-    // スワイプした時に表示するアクションの定義
+    /// スワイプした時に表示するアクションの定義
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         
         // 削除処理

--- a/MamaPapaMedicalRecord/Cover Tab/CoverViewController.swift
+++ b/MamaPapaMedicalRecord/Cover Tab/CoverViewController.swift
@@ -132,12 +132,24 @@ extension CoverViewController: UITableViewDataSource {
 }
 
 extension CoverViewController: UITableViewDelegate {
-    // 右スワイプでボタンを出す
-    func tableView(_ tableView: UITableView,
-                   commit editingStyle: UITableViewCell.EditingStyle,
-                   forRowAt indexPath: IndexPath) {
-        let targetMemo = memoDataList[indexPath.row]
-       // TODO: 削除処理を書く
-        tableView.deleteRows(at: [indexPath], with: .automatic)
+    /// セルの高さを設定するメソッド
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 30
+    }
+    
+    // スワイプした時に表示するアクションの定義
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
+        // 削除処理
+        let deleteAction = UIContextualAction(style: .destructive, title: "削除") { (action, view, completionHandler) in
+            //削除処理を記述
+            print("削除がタップされた")
+            
+            // 実行結果に関わらず記述
+            completionHandler(true)
+        }
+        
+        // 定義したアクションをセット
+        return UISwipeActionsConfiguration(actions: [deleteAction])
     }
 }

--- a/MamaPapaMedicalRecord/Record Notes List Tab/RecordNotesListViewController.swift
+++ b/MamaPapaMedicalRecord/Record Notes List Tab/RecordNotesListViewController.swift
@@ -57,4 +57,20 @@ extension RecordNotesListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 30
     }
+    
+    // スワイプした時に表示するアクションの定義
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        
+        // 削除処理
+        let deleteAction = UIContextualAction(style: .destructive, title: "削除") { (action, view, completionHandler) in
+            //削除処理を記述
+            print("削除がタップされた")
+            
+            // 実行結果に関わらず記述
+            completionHandler(true)
+        }
+        
+        // 定義したアクションをセット
+        return UISwipeActionsConfiguration(actions: [deleteAction])
+    }
 }


### PR DESCRIPTION
## やったこと
*【記録ノート一覧画面作成】削除ボタンの実装
* 表紙画面の削除ボタンの実装

## 画像　

<img width="240" alt="スクリーンショット 2023-10-08 9 14 59" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/34c5226e-26be-4d20-bdfb-cd6eda52e535">
<img width="240" alt="スクリーンショット 2023-10-08 9 18 16" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/f97a46d1-998a-4f98-9c79-c714f0e759f7">

## 動作確認
- 記録ノート一覧画面のtableviewをスワイプすると削除ボタンが表示されることを確認した
- 表紙画面のtableviewをスワイプすると削除ボタンが表示されることを確認した(なぜか表紙のtableviewをスワイプすると「delete」という表示であったため修正しました)

レビューをお願いします。@tomokazuTakahashi2
