### PR TITLE
【メモ画面_痙攣】FireStoreで保存処理を実装しました。

### DIFF
--- a/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.swift
+++ b/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.swift
@@ -38,9 +38,9 @@ final class ConvulsionsViewController: UIViewController {
     /// 痙攣（時間）
     @IBOutlet private weak var convulsionsSecondTextField: UITextField!
     /// 意識「あり」ボタン
-    @IBOutlet weak var consciousnessYesButton: CustomButton!
+    @IBOutlet private weak var consciousnessYesButton: CustomButton!
     /// 意識「なし」ボタン
-    @IBOutlet weak var consciousnessNoButton: CustomButton!
+    @IBOutlet private weak var consciousnessNoButton: CustomButton!
     /// 体温
     @IBOutlet private weak var temperatureTextField: UITextField!
     /// メモ

--- a/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.swift
+++ b/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.swift
@@ -258,7 +258,7 @@ final class ConvulsionsViewController: UIViewController {
             "imageURL": imageURL
         ]
         
-        firebaseService.saveDataToFirestore(collection: "consciousness", data: data) { [weak self] error in
+        firebaseService.saveDataToFirestore(collection: "convulsions", data: data) { [weak self] error in
             guard let self = self else { return }
             if let error = error {
                 print("データの保存エラー: \(error)")

--- a/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.xib
+++ b/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.xib
@@ -10,6 +10,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ConvulsionsViewController" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
             <connections>
+                <outlet property="consciousnessNoButton" destination="uDM-s8-CqQ" id="k2Q-Bz-HdK"/>
+                <outlet property="consciousnessYesButton" destination="U4A-hs-Vc7" id="YW9-0g-bfF"/>
                 <outlet property="convulsionsMinuteTextField" destination="y6R-wk-ZBG" id="10w-5F-Ilp"/>
                 <outlet property="convulsionsSecondTextField" destination="5ud-XX-iFg" id="jLq-pB-TAj"/>
                 <outlet property="imageView" destination="Vrp-f0-QRf" id="sjB-TZ-2zD"/>
@@ -270,13 +272,12 @@
                         <constraint firstAttribute="height" constant="50" id="zbw-5n-XxJ"/>
                     </constraints>
                 </view>
-                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="nVu-of-VTR">
+                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="nVu-of-VTR" customClass="PlaceHolderTextView" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="298" width="414" height="150"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="150" id="Obt-e3-DEz"/>
                     </constraints>
-                    <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                     <color key="textColor" systemColor="labelColor"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.xib
+++ b/MamaPapaMedicalRecord/Memo Tab/ConvulsionsViewController.xib
@@ -138,7 +138,7 @@
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4A-hs-Vc7" customClass="CustomButton" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
                                     <rect key="frame" x="129" y="8" width="60" height="34"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="34" id="glE-Th-oNA"/>
                                         <constraint firstAttribute="width" constant="60" id="uGW-4O-s6A"/>
@@ -162,7 +162,7 @@
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uDM-s8-CqQ" customClass="CustomButton" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
                                     <rect key="frame" x="189" y="8" width="60" height="34"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="60" id="WTi-be-oel"/>
                                         <constraint firstAttribute="height" constant="34" id="mHa-BA-ANL"/>

--- a/MamaPapaMedicalRecord/Memo Tab/DiarrheaViewController.xib
+++ b/MamaPapaMedicalRecord/Memo Tab/DiarrheaViewController.xib
@@ -291,7 +291,7 @@
                             <rect key="frame" x="0.0" y="200" width="414" height="50"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jdo-3e-Ghy" customClass="CustomButton" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
-                                    <rect key="frame" x="77.5" y="10" width="115" height="30"/>
+                                    <rect key="frame" x="77.5" y="10" width="117" height="30"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="fz8-zl-fWm"/>
@@ -301,7 +301,7 @@
                                         <attributedString key="attributedTitle">
                                             <fragment content="赤い箇所がある">
                                                 <attributes>
-                                                    <font key="NSFont" size="13" name=".HiraKakuInterface-W3"/>
+                                                    <font key="NSFont" metaFont="system"/>
                                                     <font key="NSOriginalFont" metaFont="smallSystem"/>
                                                 </attributes>
                                             </fragment>
@@ -323,7 +323,7 @@
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mgX-LN-Qrr" customClass="CustomButton" customModule="MamaPapaMedicalRecord" customModuleProvider="target">
-                                    <rect key="frame" x="192.5" y="10" width="102.5" height="30"/>
+                                    <rect key="frame" x="194.5" y="10" width="102.5" height="30"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="102.5" id="5w0-cm-2Kr"/>
@@ -349,7 +349,7 @@
                                     </connections>
                                 </button>
                                 <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Pa5-x2-1x4">
-                                    <rect key="frame" x="295" y="10" width="89" height="30"/>
+                                    <rect key="frame" x="297" y="10" width="87" height="30"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="rAa-gF-9ID"/>
                                     </constraints>


### PR DESCRIPTION
## やったこと
* 【メモ画面_痙攣】FireStoreで保存処理を実装

## 画像　
<img width="240" alt="スクリーンショット 2023-10-10 15 46 47" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/d8f115ad-5493-4469-b8f7-62f8cd037d76">
<img width="240" alt="スクリーンショット 2023-10-10 15 46 54" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/8aa1312f-3be1-4c18-b3b0-32e26d0d721d">
<img width="240" alt="スクリーンショット 2023-10-10 15 47 00" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/f28c7d87-d43f-46e8-901d-68fb80cea6f5">

## 動作確認
- 意識ボタンをタップすると白、タップしないとグレーに表示されていることを確認した
- メモのplaceholderが表示されていることを確認した

レビューをお願いします。
@tomokazuTakahashi2 