### PR TITLE
【受診画面作成】写真選択とカメラを実装しました

### DIFF
--- a/MamaPapaMedicalRecord/Medical Examination Tab/MedicalExaminationViewController.swift
+++ b/MamaPapaMedicalRecord/Medical Examination Tab/MedicalExaminationViewController.swift
@@ -35,9 +35,19 @@ final class MedicalExaminationViewController: UIViewController {
     
     /// 写真挿入ボタンをタップ
     @IBAction private func tapPhotoButton(_ sender: UIButton) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .photoLibrary
+        picker.delegate = self
+        present(picker, animated: true)
+        self.present(picker, animated: true)
     }
     /// カメラ・動画起動ボタンをタップ
     @IBAction private func tapCameraButton(_ sender: UIButton) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = self
+        // UIImagePickerController カメラを起動する
+        present(picker, animated: true, completion: nil)
     }
     /// 削除ボタンをタップ
     @IBAction private func tapTrashButton(_ sender: UIButton) {
@@ -54,5 +64,21 @@ final class MedicalExaminationViewController: UIViewController {
     
     @objc func saveButtonTapped() {
         // TODO: 保存処理
+    }
+}
+
+// MARK: - UIImagePickerControllerDelegate
+
+extension MedicalExaminationViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let selectedImage = info[.originalImage] as? UIImage {
+            imageView.image = selectedImage
+        }
+        self.dismiss(animated: true)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        self.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
## やったこと
* 【受診画面作成】写真選択とカメラを実装

## 画像　
<img width="240" alt="スクリーンショット 2023-10-12 14 29 51" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/e91f0026-9501-4577-814b-e37399dcd87a">
<img width="240" alt="スクリーンショット 2023-10-12 14 29 59" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/3a964c95-bd8b-435b-8829-f74977cfc1d4">
<img width="240" alt="スクリーンショット 2023-10-12 14 30 05" src="https://github.com/Annaminniee/MamaPapaMedicalRecord/assets/138358044/0819379c-dd2e-4237-b1c3-8d9fab2de730">

## 動作確認
- 受診画面の写真アイコンをタップするとアルバムに移動して、imageviewに選択された写真が挿入されることを確認した
- カメラアイコンをタップしてカメラが起動することを確認した

レビューをお願いします。
@tomokazuTakahashi2 